### PR TITLE
Support for out-of-the-box Ubuntu 14.04

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.1.2'
+ruby '2.0.0'
 gem 'jekyll', '~> 2.2.0'
 gem 'rack-jekyll', "~> 0.4.1", git: "https://github.com/adaoraul/rack-jekyll.git"
 gem 'jekyll-sass'


### PR DESCRIPTION
I don't see any dependencies for Ruby 2.1.2 and Ubuntu 14.04 (and I'm sure others) only goes to 2.0 in it's repository.  Unless there is a need for this, we may be able to loosen our requirements for ruby versions.
